### PR TITLE
Use server-configuration from test dir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemPropertyVariables>
-                <org.protege.owl.server.configuration>server-configuration.json</org.protege.owl.server.configuration>
+                <org.protege.owl.server.configuration>${project.build.testOutputDirectory}/server-configuration.json</org.protege.owl.server.configuration>
               </systemPropertyVariables>
             </configuration>
           </plugin>

--- a/src/test/java/org/protege/editor/owl/integration/BaseTest.java
+++ b/src/test/java/org/protege/editor/owl/integration/BaseTest.java
@@ -93,17 +93,10 @@ public abstract class BaseTest {
    
     @BeforeClass
     public static void startServer() throws Exception {
-    	String cfn = "server-configuration.json";
-    	
-    	File f = new File(cfn);
-    	boolean bool = f.exists();
-
     	BasicConfigurator.configure();
-    	httpServer = new HTTPServer(cfn);
+    	httpServer = new HTTPServer();
     	httpServer.start();
-    	
     }
-    
 
 
     protected LocalHttpClient getAdmin() {


### PR DESCRIPTION
Only use the config specified in the pom file. Rather than specifying
it twice. Also fetch the config relative to the test output dir.